### PR TITLE
add environment.yml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,29 @@
+name: hpnet
+channels:
+  - pytorch
+  - nvidia
+  - conda-forge
+  - anaconda
+  - orbingol
+dependencies:
+  - python
+  - numpy=1.19.2
+  - pytorch=1.7.0
+  - tensorflow=1.15.0
+  - transforms3d
+  - h5py
+  - trimesh
+  - scipy
+  - geomdl
+  - pykdtree
+  - seaborn
+  - matplotlib
+  - pip
+  - pip:
+    - torch_scatter==2.0.6
+    - lapsolver==1.1.0
+    - pytorch_utils==0.5.5
+    - open3d==0.11.2
+    - ipdb==0.12.3
+    - lap==0.4.0
+    - scikit-learn==0.24.2


### PR DESCRIPTION
Installing the dependencies via pip install requirements.txt does not work due to some specific versions of packages not existing. Added an environment file that can instantiate a working environment via the command
```
conda env create -f environment.yml
```
which works as of April 2023.